### PR TITLE
refactor: Make RandomAccessIterator requirement more explicit.

### DIFF
--- a/CSCI 115 Project/CSCI 115 Project/profile.h
+++ b/CSCI 115 Project/CSCI 115 Project/profile.h
@@ -1,0 +1,23 @@
+#ifndef PROFILE_H
+#define PROFILE_H
+
+#include <chrono>
+#include <algorithm>
+
+/**
+ * Profiles the runtime a function.
+ * 
+ * @param func function of any return type accepting args as arguments.
+ * @param args variable number of arguments to be passed into func.
+ * @returns the runtime of func when called with arguments args in microseconds.
+ */ 
+template <typename Duration = std::chrono::microseconds, typename F, typename ... Args>
+typename Duration::rep profile(F&& func, Args&&... args)
+{
+    const auto start = std::chrono::high_resolution_clock::now();
+    std::forward<F>(func)(std::forward<Args>(args)...);
+    const auto end = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(end - start).count();
+}
+
+#endif

--- a/CSCI 115 Project/CSCI 115 Project/sort_algs.h
+++ b/CSCI 115 Project/CSCI 115 Project/sort_algs.h
@@ -3,8 +3,8 @@
 
 #include <vector>
 
-template <typename GenericIterator>
-void exch(GenericIterator i, GenericIterator j) {
+template <typename RandomAccessIterator>
+void exch(RandomAccessIterator i, RandomAccessIterator j) {
     auto tmp = *i;
     *i = *j;
     *j = tmp;
@@ -13,17 +13,16 @@ void exch(GenericIterator i, GenericIterator j) {
 /**
  * Sorts the elements in the range [begin, end) in ascending order. 
  * The order of equal elements is not guaranteed to be preserved.
- * GenericIterator must meet the requirements of ValueSwappable and
- * RandomAccessIterator. The type of dereferenced GenericIterator must
- * be comparable with the < operator. 
+ * Iterators must meet the requirements of ValueSwappable. The type of
+ * dereferenced RandomAccessIterator must be comparable with the < operator. 
  * 
  * @param begin iterator pointing to the first element in the range to be
  *              sorted, such as the iterator returnd by std::vector::begin.
  * @peram end   iterator referring to the past-the-end element in the range to
  *              be sorted, such as the iterator returned by std::vector::end.
  */ 
-template <typename GenericIterator>
-void insertion_sort(GenericIterator begin, GenericIterator end) {
+template <typename RandomAccessIterator>
+void insertion_sort(RandomAccessIterator begin, RandomAccessIterator end) {
     if (begin == end) return;
 
     for (auto i = begin + 1; i < end; ++i) {
@@ -40,17 +39,16 @@ void insertion_sort(GenericIterator begin, GenericIterator end) {
 /**
  * Sorts the elements in the range [begin, end) in ascending order. 
  * The order of equal elements is not guaranteed to be preserved.
- * GenericIterator must meet the requirements of ValueSwappable and
- * RandomAccessIterator. The type of dereferenced GenericIterator must
- * be comparable with the < operator.
+ * Iterators must meet the requirements of ValueSwappable. The type of
+ * dereferenced RandomAccessIterator must be comparable with the < operator. 
  * 
  * @param begin iterator pointing to the first element in the range to be
  *              sorted, such as the iterator returnd by std::vector::begin.
  * @peram end   iterator referring to the past-the-end element in the range to
  *              be sorted, such as the iterator returned by std::vector::end.
  */ 
-template <typename GenericIterator>
-void selection_sort(GenericIterator begin, GenericIterator end) {
+template <typename RandomAccessIterator>
+void selection_sort(RandomAccessIterator begin, RandomAccessIterator end) {
     if (begin == end) return;
 
     for (auto i = begin; i < end - 1; ++i) {
@@ -67,17 +65,16 @@ void selection_sort(GenericIterator begin, GenericIterator end) {
 /**
  * Sorts the elements in the range [begin, end) in ascending order. 
  * The order of equal elements is not guaranteed to be preserved.
- * GenericIterator must meet the requirements of ValueSwappable and
- * RandomAccessIterator. The type of dereferenced GenericIterator must
- * be comparable with the < operator. 
+ * Iterators must meet the requirements of ValueSwappable. The type of
+ * dereferenced RandomAccessIterator must be comparable with the < operator. 
  * 
  * @param begin iterator pointing to the first element in the range to be
  *              sorted, such as the iterator returnd by std::vector::begin.
  * @peram end   iterator referring to the past-the-end element in the range to
  *              be sorted, such as the iterator returned by std::vector::end.
  */ 
-template <typename GenericIterator>
-void bubble_sort(GenericIterator begin, GenericIterator end) {
+template <typename RandomAccessIterator>
+void bubble_sort(RandomAccessIterator begin, RandomAccessIterator end) {
     if (begin == end) return;
 
     bool didSwap = false;

--- a/CSCI 115 Project/CSCI 115 Project/tests/profile_test.cpp
+++ b/CSCI 115 Project/CSCI 115 Project/tests/profile_test.cpp
@@ -1,0 +1,52 @@
+#include "catch.hpp"
+#include "../profile.h"
+#include <thread>
+#include <chrono>
+#include <functional>
+
+using std::chrono::duration_cast;
+using std::chrono::microseconds;
+using std::chrono::milliseconds;
+
+TEST_CASE( "profile" ) {
+
+    SECTION( "Measures .001 second delay accurately." ) {
+        auto delay = microseconds(1000);
+        auto tolerance = delay.count() * 0.1; // Allowing 10% margin of error.
+        auto duration = profile(
+            [delay]() { std::this_thread::sleep_for(delay); }
+        );
+        auto diff = std::abs(duration - delay.count());
+        REQUIRE(diff < tolerance);
+    }
+
+    SECTION( "Measures .01 second delay accurately." ) {
+        auto delay = microseconds(10000);
+        auto tolerance = delay.count() * 0.1; // Allowing 10% margin of error.
+        auto duration = profile(
+            [delay]() { std::this_thread::sleep_for(delay); }
+        );
+        auto diff = std::abs(duration - delay.count());
+        REQUIRE(diff < tolerance);
+    }
+
+    SECTION( "Measures .1 second delay accurately." ) {
+        auto delay = microseconds(100000);
+        auto tolerance = delay.count() * 0.1; // Allowing 10% margin of error.
+        auto duration = profile(
+            [delay]() { std::this_thread::sleep_for(delay); }
+        );
+        auto diff = std::abs(duration - delay.count());
+        REQUIRE(diff < tolerance);
+    }
+
+    SECTION( "Measures 1 second delay accurately." ) {
+        auto delay = microseconds(1000000);
+        auto tolerance = delay.count() * 0.1; // Allowing 10% margin of error.
+        auto duration = profile(
+            [delay]() { std::this_thread::sleep_for(delay); }
+        );
+        auto diff = std::abs(duration - delay.count());
+        REQUIRE(diff < tolerance);
+    }
+}


### PR DESCRIPTION
My previous use of GenericIterator was not correct. The iterator types should be declared as RandomAccessIterator to enforce that the iterators be random access iterators allowing for the use of operations such as it++, it--, it1 + it2, it1 - it2, it + n where n is some integer, etc. 

If iterators are not of type RandomAccessIterator, then the behavior of these operations is undefined and std::distance(it1, it2), std::next(it, n), etc, must be used instead to increment iterators, take their difference, etc.

Since the begin() and end() container of container classes in the STL return iterators of type RandomAccessIterator, we can just enforce this and make working with the iterators simpler.

See https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator for supported operations of RandomAccessIterator.